### PR TITLE
chore: remove unused icon packages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,6 @@
 	<link href="static/css/swiper.css" rel="stylesheet" type="text/css">
 	<link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
 
-	<!-- ICONS -->
-	<script src="https://unpkg.com/@phosphor-icons/web"></script>
-
 	<!-- FONTS -->
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/pages/home/swiper.html
+++ b/pages/home/swiper.html
@@ -81,8 +81,6 @@
 
 <div class="clear" style="margin-bottom: 100px;"></div>
 
-<script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
-<script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 
 


### PR DESCRIPTION
This PR removes the icon packages to speed up website performance since the icons on the site are hardcoded. No visual changes were made